### PR TITLE
file server contrib update

### DIFF
--- a/contrib/file-server/README.md
+++ b/contrib/file-server/README.md
@@ -11,6 +11,8 @@ Obviously the following solution is a proposition and can be modified according 
 
 ![File Server](images/FileServerUpload.png)
 
+If your cluster is Openshift, deploy the file server in any project/namespace but the `default` project.
+
 Install the Bitnami Helm Chart
 
 ```bash

--- a/contrib/file-server/README.md
+++ b/contrib/file-server/README.md
@@ -55,6 +55,14 @@ Get the [httpd-pvc.yaml](./httpd-pvc.yaml) file and create a PVC to persist all 
 kubectl create -f httpd-pvc.yaml
 ```
 
+Create a secret to authenticate to the Docker Hub registry to pull images:
+```
+kubectl create secret docker-registry docker-secret \
+    --docker-server=docker.io \
+    --docker-username=<username> \
+    --docker-password=<password>
+``` 
+
 Get the [httpd-values.yaml](./httpd-values.yaml) file and instanciate the Apache Http file server :
 
 ```bash

--- a/contrib/file-server/httpd-values.yaml
+++ b/contrib/file-server/httpd-values.yaml
@@ -2,3 +2,10 @@ containerSecurityContext:
   readOnlyRootFilesystem: false
 httpdConfConfigMap: httpd-cm
 htdocsPVC: httpd-pvc
+image:
+  repository: bitnamilegacy/apache
+  pullSecrets:
+    - docker-secret
+extraPodSpec:
+  securityContext:
+    fsGroup: 1001

--- a/contrib/file-server/httpd-values.yaml
+++ b/contrib/file-server/httpd-values.yaml
@@ -6,6 +6,3 @@ image:
   repository: bitnamilegacy/apache
   pullSecrets:
     - docker-secret
-extraPodSpec:
-  securityContext:
-    fsGroup: 1001


### PR DESCRIPTION
1) pull images from docker.io/bitnamilegacy/apache - see https://github.com/bitnami/charts/issues/35164 
2) ensure that /opt/bitnami/apache/htdocs is owned by the (non-root) user used to run the container
3) change the instructions to create a pull secret